### PR TITLE
Confirm and cancel sell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Debugger output
 debug
+
+.idea/

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -20,14 +20,18 @@ type Action struct {
 	UnitPrice currency.Currency
 }
 
+// ActionQueue : Ordered queue of actions. Oldest on left, newest on right.
+type ActionQueue []Action
+
 // Portfolio : User's stock holdings, stockName -> quantity
 type Portfolio map[string]uint
 
 // Account : State of a particular account
 type Account struct {
-	Balance             currency.Currency
-	BuyQueue, SellQueue []Action
-	Portfolio           Portfolio
+	Balance   currency.Currency
+	BuyQueue  ActionQueue
+	SellQueue ActionQueue
+	Portfolio Portfolio
 }
 
 // Accounts : Maps name -> Account
@@ -141,13 +145,13 @@ func (ac *Account) RemoveFunds(amount currency.Currency) error {
 	return nil
 }
 
-// PopLatestBuy : Returns and removes the most recent Buy in a queue
-func (ac *Account) PopLatestBuy() (Action, bool) {
+// PopNewest : Removes and returns the most recent action in a queue
+func (aq *ActionQueue) PopNewest() (Action, bool) {
 	// gobuild says:
 	//   Can't use Action as nil so we send back a bool to indicate hit/miss
 
 	// Check for empty queue
-	queueLen := len(ac.BuyQueue)
+	queueLen := len(*aq)
 	if queueLen == 0 {
 		return Action{}, false
 	}
@@ -155,7 +159,7 @@ func (ac *Account) PopLatestBuy() (Action, bool) {
 	// Last item appended to queue will be the most recent.
 	// Copy the last item then shrink the queue.
 	var latestAction Action
-	latestAction, ac.BuyQueue = ac.BuyQueue[queueLen-1], ac.BuyQueue[:queueLen-1]
+	latestAction, *aq = (*aq)[queueLen-1], (*aq)[:queueLen-1]
 
 	return latestAction, true
 }

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -14,17 +14,20 @@ var (
 
 // Action : A Buy or Sell request that can expire
 type Action struct {
-	time      time.Time
-	stock     string
-	units     uint
-	unitPrice currency.Currency
+	Time      time.Time
+	Stock     string
+	Units     uint
+	UnitPrice currency.Currency
 }
+
+// Portfolio : User's stock holdings, stockName -> quantity
+type Portfolio map[string]uint
 
 // Account : State of a particular account
 type Account struct {
 	Balance             currency.Currency
 	BuyQueue, SellQueue []Action
-	Portfolio           map[string]int
+	Portfolio           Portfolio
 }
 
 // Accounts : Maps name -> Account
@@ -42,16 +45,17 @@ func NewAccountStore() *AccountStore {
 	return &as
 }
 
-func (ac Account) addStockToPortfolio(stock string, units int) bool {
+// AddStockToPortfolio : Give a user some stock
+func (ac *Account) AddStockToPortfolio(stock string, units uint) {
 	currentUnits, ok := ac.Portfolio[stock]
 	if !ok {
 		currentUnits = 0
 	}
 	ac.Portfolio[stock] = currentUnits + units
-	return true
 }
 
-func (ac Account) removeStockFromPortfolio(stock string, units int) bool {
+// RemoveStockFromPortfolio : Remove stocks from a user
+func (ac *Account) RemoveStockFromPortfolio(stock string, units uint) bool {
 	currentUnits, ok := ac.Portfolio[stock]
 	if !ok || currentUnits-units < 0 {
 		log.Notice("User does not have enough stock to sell")
@@ -61,7 +65,8 @@ func (ac Account) removeStockFromPortfolio(stock string, units int) bool {
 	return true
 }
 
-func (ac Account) getPortfolioStockUnits(stock string) int {
+// GetPortfolioStockUnits : Number of units users holds of a stock
+func (ac *Account) GetPortfolioStockUnits(stock string) uint {
 	return ac.Portfolio[stock]
 
 }
@@ -82,24 +87,24 @@ func (as AccountStore) GetAccount(name string) *Account {
 }
 
 // AddToBuyQueue ; Add a stock S to the buy queue
-func (ac Account) AddToBuyQueue(stock string, units uint, unitPrice currency.Currency) bool {
+func (ac *Account) AddToBuyQueue(stock string, units uint, unitPrice currency.Currency) bool {
 	currentAction := Action{
-		time:      time.Now(),
-		stock:     stock,
-		units:     units,
-		unitPrice: unitPrice,
+		Time:      time.Now(),
+		Stock:     stock,
+		Units:     units,
+		UnitPrice: unitPrice,
 	}
 	ac.BuyQueue = append(ac.BuyQueue, currentAction)
 	return true
 }
 
 // AddToSellQueue ; Add a stock S to the buy queue
-func (ac Account) AddToSellQueue(stock string, units uint, unitPrice currency.Currency) bool {
+func (ac *Account) AddToSellQueue(stock string, units uint, unitPrice currency.Currency) bool {
 	currentAction := Action{
-		time:      time.Now(),
-		stock:     stock,
-		units:     units,
-		unitPrice: unitPrice,
+		Time:      time.Now(),
+		Stock:     stock,
+		Units:     units,
+		UnitPrice: unitPrice,
 	}
 	ac.SellQueue = append(ac.SellQueue, currentAction)
 	return true
@@ -114,6 +119,9 @@ func (as AccountStore) CreateAccount(name string) error {
 
 	// Add account with initial values
 	as.Accounts[name] = &Account{}
+
+	// Initialize the account's portfolio
+	as.Accounts[name].Portfolio = make(Portfolio)
 
 	return nil
 }
@@ -131,4 +139,29 @@ func (ac *Account) RemoveFunds(amount currency.Currency) error {
 		return errors.New("Insufficient Funds")
 	}
 	return nil
+}
+
+// PopLatestBuy : Returns and removes the most recent Buy in a queue
+func (ac *Account) PopLatestBuy() (Action, bool) {
+	// gobuild says:
+	//   Can't use Action as nil so we send back a bool to indicate hit/miss
+
+	// Check for empty queue
+	queueLen := len(ac.BuyQueue)
+	if queueLen == 0 {
+		return Action{}, false
+	}
+
+	// Last item appended to queue will be the most recent.
+	// Copy the last item then shrink the queue.
+	var latestAction Action
+	latestAction, ac.BuyQueue = ac.BuyQueue[queueLen-1], ac.BuyQueue[:queueLen-1]
+
+	return latestAction, true
+}
+
+// IsExpired : True if the action's timestamp is older than its validity window
+func (act *Action) IsExpired() bool {
+	expiry := act.Time.Add(time.Second * 60)
+	return time.Now().After(expiry)
 }

--- a/app.go
+++ b/app.go
@@ -12,9 +12,9 @@ import (
 	"github.com/op/go-logging"
 
 
-	"Milestone1/accounts"
-	"Milestone1/commands"
-	"Milestone1/quotecache"
+	"github.com/distributeddesigns/milestone1/accounts"
+	"github.com/distributeddesigns/milestone1/commands"
+	"github.com/distributeddesigns/milestone1/quotecache"
 )
 
 // Globals

--- a/app.go
+++ b/app.go
@@ -11,7 +11,6 @@ import (
 	"github.com/distributeddesigns/currency"
 	"github.com/op/go-logging"
 
-
 	"github.com/distributeddesigns/milestone1/accounts"
 	"github.com/distributeddesigns/milestone1/commands"
 	"github.com/distributeddesigns/milestone1/quotecache"
@@ -233,7 +232,7 @@ func executeBuy(cmd command) bool {
 
 	if account == nil {
 		log.Noticef("User %s does not have an account", account)
-		return false;
+		return false
 	}
 
 	stockSymbol := cmd.Args[0]
@@ -256,9 +255,9 @@ func executeBuy(cmd command) bool {
 	if wholeShares == 0 {
 		log.Notice("Amount specified to buy less than single stock unit")
 		return true
-	} else {
-		log.Notice("User %s set purchase order for %d shares of stock %s", cmd.UserID, wholeShares, stockSymbol)
 	}
+
+	log.Notice("User %s set purchase order for %d shares of stock %s", cmd.UserID, wholeShares, stockSymbol)
 
 	dollarAmount.Sub(cashRemainder)
 	account.RemoveFunds(dollarAmount)
@@ -271,7 +270,7 @@ func executeSell(cmd command) bool {
 
 	if account == nil {
 		log.Noticef("User %s does not have an account", account)
-		return false;
+		return false
 	}
 
 	stockSymbol := cmd.Args[0]
@@ -302,4 +301,3 @@ func executeSell(cmd command) bool {
 
 	return account.AddToSellQueue(stockSymbol, wholeShares, userQuote.Price)
 }
-


### PR DESCRIPTION
Built on top of #24 and #25. Resolves #10 and #11.

**Confirm Sell** gives the user the profits from the sale. **Cancel Sell** returns the stock to the user's portfolio.

ca98d40 : Fixed **Sell** to deduct stock from the portfolio to prevent double selling. Also refactored `BuyQueue` and `SellQueue` interactions so I could use one method (`PopNewest`) to act on either queue.

Decided to make expiration its own issue (#26) to focus on the logic of buy/sell. I see it more as a fun implementation challenge than something necessary for the first milestone. Runs are completing <5s so things will never get a chance to age out, anyway.

Here's a runtime log with elevated logging. It takes a few tries to get a quote from the server that triggers enough buy/sells with interesting behavior.:
<img width="762" alt="screen shot 2017-01-21 at 2 53 30 pm" src="https://cloud.githubusercontent.com/assets/6734837/22178449/270bd634-dfeb-11e6-8416-21a311258ba5.png">
