### PR TITLE
Generate audit logfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 debug
 
 .idea/
+logs/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # Milestone1
-Milestone 1
+Monolithic implementation of the trading server. What could go wrong?
+
+## Installing
+```shell
+mkdir -p $GOPATH/src/github.com/distributeddesigns/milestone1
+cd $GOPATH/src/github.com/distributeddesigns
+
+# Note the change of M -> m; Fixes ref problem on case sensitive
+# file systems (i.e. windows)
+git clone https://github.com/DistributedDesigns/Milestone1.git milestone1
+
+cd milestone1
+
+go get
+
+# creates a disposable temp binary; no need to `go install` then invoke
+go run app.go ${workload file}
+```
+You can get workload files from the [docs repo][docs] or the [project website][project-website].
+
+## Validating logs
+New logs for each run will be created in `./logs`. You can do partial validation for the schema using [logfile.xsd](./logfile.xsd) and `xmllint`.
+```shell
+xmllint --version # should be > 20624
+xmllint --schema logfile.xsd --noout logs/yourlogfile.xml
+```
+Logfile troubleshooting is available on the [project website][logfile-faqs].
+
+[docs]: https://github.com/distributeddesigns/docs
+[project-website]: http://www.ece.uvic.ca/~seng462/ProjectWebSite/index.shtml
+[logfile-faqs]: http://www.ece.uvic.ca/~seng462/ProjectWebSite/ExampleLog.html

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	consoleLog = logging.MustGetLogger("audit")
+	consoleLog = logging.MustGetLogger("console")
 )
 
 // Action : A Buy or Sell request that can expire

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	log = logging.MustGetLogger("audit")
+	consoleLog = logging.MustGetLogger("audit")
 )
 
 // Action : A Buy or Sell request that can expire
@@ -62,7 +62,7 @@ func (ac *Account) AddStockToPortfolio(stock string, units uint) {
 func (ac *Account) RemoveStockFromPortfolio(stock string, units uint) bool {
 	currentUnits, ok := ac.Portfolio[stock]
 	if !ok || currentUnits-units < 0 {
-		log.Notice("User does not have enough stock to sell")
+		consoleLog.Notice("User does not have enough stock to sell")
 		return false
 	}
 	ac.Portfolio[stock] = currentUnits - units

--- a/app.go
+++ b/app.go
@@ -223,7 +223,7 @@ func executeQuote(cmd command) bool {
 	}
 
 	// get a quote for the stock. (cache will determine if a fresh one is needed)
-	quote, err := quotecache.GetQuote(cmd.UserID, stock)
+	quote, err := quotecache.GetQuote(cmd.UserID, stock, cmd.ID)
 	if err != nil {
 		consoleLog.Error(err.Error())
 		return false
@@ -251,7 +251,7 @@ func executeBuy(cmd command) bool {
 		return false
 	}
 	//User wants to buy y worth of x shares.
-	userQuote, err := quotecache.GetQuote(cmd.UserID, stockSymbol)
+	userQuote, err := quotecache.GetQuote(cmd.UserID, stockSymbol, cmd.ID)
 
 	if err != nil {
 		consoleLog.Noticef("Quote of stock %s for user %s is invalid", stockSymbol, cmd.UserID)
@@ -353,7 +353,7 @@ func executeSell(cmd command) bool {
 		return false
 	}
 
-	userQuote, err := quotecache.GetQuote(cmd.UserID, stockSymbol)
+	userQuote, err := quotecache.GetQuote(cmd.UserID, stockSymbol, cmd.ID)
 
 	if err != nil {
 		consoleLog.Noticef("Quote of stock %s for user %s is invalid", stockSymbol, cmd.UserID)

--- a/auditlogger/auditlogger.go
+++ b/auditlogger/auditlogger.go
@@ -131,7 +131,7 @@ func LogCommand(cmd commands.Command) {
 		}
 	}
 
-	timeInMillisec := time.Now().Unix() * 1000
+	timeInMillisec := time.Now().UnixNano() / 1000
 
 	xmlElement := fmt.Sprintf(`
 	<userCommand>

--- a/auditlogger/auditlogger.go
+++ b/auditlogger/auditlogger.go
@@ -131,7 +131,7 @@ func LogCommand(cmd commands.Command) {
 		}
 	}
 
-	timeInMillisec := time.Now().UnixNano() / 1000
+	timeInMillisec := time.Now().UnixNano() / 1000000
 
 	xmlElement := fmt.Sprintf(`
 	<userCommand>

--- a/auditlogger/auditlogger.go
+++ b/auditlogger/auditlogger.go
@@ -1,0 +1,171 @@
+package auditlogger
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/distributeddesigns/milestone1/commands"
+	logging "github.com/op/go-logging"
+)
+
+const outdir string = "logs"
+
+var (
+	auditlogFile *os.File
+	servername   string
+
+	consoleLog = logging.MustGetLogger("console")
+)
+
+// Init : Opens a new log file and prepares attaches it to the logger.
+//  	Returns a callback that will write the XML footer and close the
+//		file reference.
+func Init() func() {
+	// Get a server name from the environment
+	if os.Getenv("SERVERNAME") == "" {
+		servername = "UNKNOWN"
+	} else {
+		servername = os.Getenv("SERVERNAME")
+	}
+
+	// Create a new file based on the current time
+	now := time.Now()
+	auditlogFileName := fmt.Sprintf("%s/%d%02d%02dT%02d%02d%02d.xml",
+		outdir, now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), now.Second(),
+	)
+
+	// Create the ./logs directory, if we need to
+	if _, err := os.Stat(outdir); os.IsNotExist(err) {
+		consoleLog.Debugf("Creating log directory at ./%s", outdir)
+		if dirErr := os.Mkdir(outdir, 0755); dirErr != nil {
+			// Don't bother running if we can't generate a log file.
+			consoleLog.Fatalf("Couldn't create log directory. Terminating execution.\n%s", dirErr.Error())
+		}
+	} else if err != nil {
+		// Don't swallow the error from os.Stat
+		// Bail if something weird happened.
+		consoleLog.Fatalf("Couldn't create log directory. Terminating execution.\n%s", err.Error())
+	}
+
+	// Open the file for writing
+	var createErr error
+	auditlogFile, createErr = os.Create(auditlogFileName)
+	if createErr != nil {
+		consoleLog.Fatalf("Couldn't create log file. Terminating execution.\n%s", createErr.Error())
+	}
+	// closing the audit file is the responsiblity of the caller to Init()
+
+	// Write our logfile header
+	auditlogFile.WriteString("<?xml version=\"1.0\"?>\n<log>\n")
+
+	// Return an anonymous function that creates a closure over the audit file.
+	// If we defered File.Close() in Init() we'd close the audit file
+	// as soon as Init() finished.
+	return func() {
+		auditlogFile.WriteString("\n</log>\n")
+		auditlogFile.Close()
+	}
+}
+
+// LogCommand : Writes a UserCommandType to the audit log
+func LogCommand(cmd commands.Command) {
+	// Parse the optional fields. Initialized to "" which is the default case.
+	var usernameField, stockField, fileField, fundsField string
+
+	// With the exception of the admin DUMPLOG, all commands will have a
+	// userID. We'll assign it now and deal with the admin DUMPLOG reassignment
+	// in the switch. ID and command name won't have to be reassigned so we'll
+	// get those when we format the output string.
+	usernameField = formatUsername(cmd.UserID)
+
+	switch cmd.Name {
+	case commands.Add:
+		fundsField = formatFunds(cmd.Args[0])
+	case commands.Quote:
+		stockField = formatStockSymbol(cmd.Args[0])
+	case commands.Buy:
+		stockField = formatStockSymbol(cmd.Args[0])
+		fundsField = formatFunds(cmd.Args[1])
+	case commands.CommitBuy:
+		// No optional args
+		break
+	case commands.CancelBuy:
+		break
+	case commands.Sell:
+		stockField = formatStockSymbol(cmd.Args[0])
+		fundsField = formatFunds(cmd.Args[1])
+	case commands.CommitSell:
+		break
+	case commands.CancelSell:
+		break
+	case commands.SetBuyAmount:
+		stockField = formatStockSymbol(cmd.Args[0])
+		fundsField = formatFunds(cmd.Args[1])
+	case commands.SetBuyTrigger:
+		stockField = formatStockSymbol(cmd.Args[0])
+		fundsField = formatFunds(cmd.Args[1])
+	case commands.CancelSetBuy:
+		stockField = formatStockSymbol(cmd.Args[0])
+	case commands.SetSellAmount:
+		stockField = formatStockSymbol(cmd.Args[0])
+		fundsField = formatFunds(cmd.Args[1])
+	case commands.SetSellTrigger:
+		stockField = formatStockSymbol(cmd.Args[0])
+		fundsField = formatFunds(cmd.Args[1])
+	case commands.CancelSetSell:
+		stockField = formatStockSymbol(cmd.Args[0])
+	case commands.DisplaySummary:
+		break
+	case commands.DumpLog:
+		// Only way to tell difference between user / admin command
+		// is to count the number of args
+		if len(cmd.Args) == 0 {
+			// It's an admin dump
+			// FIXME: ParseCommand interpreted the filename as the user
+			fileField = formatFile(cmd.UserID)
+			usernameField = ""
+		} else {
+			// It's a user dump
+			fileField = formatFile(cmd.Args[0])
+		}
+	}
+
+	timeInMillisec := time.Now().Unix() * 1000
+
+	xmlElement := fmt.Sprintf(`
+	<userCommand>
+		<timestamp>%d</timestamp>
+		<server>%s</server>
+		<transactionNum>%d</transactionNum>
+		<command>%s</command>%s%s%s%s
+	</userCommand>`,
+		timeInMillisec, servername, cmd.ID, cmd.Name,
+		usernameField, stockField, fileField, fundsField,
+	)
+
+	auditlogFile.WriteString(xmlElement)
+}
+
+func formatUsername(name string) string {
+	return fmt.Sprintf("\n\t\t<username>%s</username>", name)
+}
+
+func formatStockSymbol(stock string) string {
+	return fmt.Sprintf("\n\t\t<stockSymbol>%s</stockSymbol>", stock)
+}
+
+func formatFile(file string) string {
+	return fmt.Sprintf("\n\t\t<filename>%s</filename>", file)
+}
+
+func formatFunds(funds string) string {
+	return fmt.Sprintf("\n\t\t<funds>%s</funds>", funds)
+}
+
+// LogQuoteServerHit : Writes a QuoteServerType to the log
+func LogQuoteServerHit(s string) {
+	// FIXME : s needs to be pre-formatted by the caller.
+	// 		Pretty bad isolation IMO. (or is it separation of concerns?)
+	auditlogFile.WriteString(s)
+}

--- a/autorequests/autorequests.go
+++ b/autorequests/autorequests.go
@@ -2,19 +2,20 @@ package autorequests
 
 import (
 	"errors"
+
 	"github.com/distributeddesigns/currency"
 
 	"github.com/op/go-logging"
 )
 
 var (
-	log = logging.MustGetLogger("audit")
+	consoleLog = logging.MustGetLogger("console")
 )
 
 // AutoRequest :  A buy or sell request for a user
-type AutoRequest struct{ 
-	Amount currency.Currency
-	Trigger currency.Currency 
+type AutoRequest struct {
+	Amount  currency.Currency
+	Trigger currency.Currency
 }
 
 // AutoRequestStore : Map stock -> user -> request
@@ -49,13 +50,13 @@ func (ars *AutoRequestStore) AddAutorequest(stock, userID string, amount currenc
 	(*ars)[stock][userID] = request
 }
 
-func (ars *AutoRequestStore) CancelAutorequest(stock, userID string) (currency.Currency, error){
+func (ars *AutoRequestStore) CancelAutorequest(stock, userID string) (currency.Currency, error) {
 	if _, found := (*ars)[stock][userID]; found {
 		delete((*ars)[stock], userID)
 		refundAmount := (*ars)[stock][userID].Amount.ToFloat()
 		theCurrency, err := currency.NewFromFloat(refundAmount)
 		if err != nil {
-			log.Error("Unable to create currency")
+			consoleLog.Error("Unable to create currency")
 		}
 		return theCurrency, nil
 	}

--- a/logfile.xsd
+++ b/logfile.xsd
@@ -1,0 +1,154 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+ <xsd:annotation>
+  <xsd:documentation xml:lang="en">
+   Log file schema for SEng 462 at the University of Victoria.
+  </xsd:documentation>
+ </xsd:annotation>
+
+ <xsd:element name="log" type="LogType"/> 
+
+<!-- The log file created by the students consists of user commands, quote server
+ hits, account changes, system events, error messages and debug messages -->
+ <xsd:complexType name="LogType">
+  <xsd:choice minOccurs="0" maxOccurs="unbounded">
+   <xsd:element name="userCommand" type="UserCommandType"/>
+   <xsd:element name="quoteServer" type="QuoteServerType"/>
+   <xsd:element name="accountTransaction" type="AccountTransactionType"/>
+   <xsd:element name="systemEvent" type="SystemEventType"/>
+   <xsd:element name="errorEvent" type="ErrorEventType"/>
+   <xsd:element name="debugEvent" type="DebugType"/>
+  </xsd:choice>
+ </xsd:complexType>
+
+<!-- User commands come from the user command files or from manual entries in 
+the students' web forms -->
+ <xsd:complexType name="UserCommandType">
+  <xsd:all>
+   <xsd:element name="timestamp" type="unixTimeLimits"/>
+   <xsd:element name="server" type="xsd:string"/>
+   <xsd:element name="transactionNum" type="xsd:positiveInteger"/>
+   <xsd:element name="command" type="commandType"/>
+   <xsd:element name="username" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="stockSymbol" type="stockSymbolType" minOccurs="0"/>
+   <xsd:element name="filename" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="funds" type="xsd:decimal" minOccurs="0"/>
+  </xsd:all>
+ </xsd:complexType>
+
+<!-- Every hit to the quote server requires a log entry with the results. The 
+price, symbol, username, timestamp and cryptokey are as returned by the quote server -->
+ <xsd:complexType name="QuoteServerType">
+  <xsd:all>
+   <xsd:element name="timestamp" type="unixTimeLimits"/>
+   <xsd:element name="server" type="xsd:string"/>
+   <xsd:element name="transactionNum" type="xsd:positiveInteger"/>
+   <xsd:element name="price" type="xsd:decimal"/>
+   <xsd:element name="stockSymbol" type="stockSymbolType"/>
+   <xsd:element name="username" type="xsd:string"/>
+   <xsd:element name="quoteServerTime" type="xsd:integer"/>
+   <xsd:element name="cryptokey" type="xsd:string"/>
+  </xsd:all>
+ </xsd:complexType>
+
+<!-- Any time a user's account is touched, an account message is printed.  
+Appropriate actions are "add" or "remove". -->
+ <xsd:complexType name="AccountTransactionType">
+  <xsd:all>
+   <xsd:element name="timestamp" type="unixTimeLimits"/>
+   <xsd:element name="server" type="xsd:string"/>
+   <xsd:element name="transactionNum" type="xsd:positiveInteger"/>
+   <xsd:element name="action" type="xsd:string"/>
+   <xsd:element name="username" type="xsd:string"/> 
+   <xsd:element name="funds" type="xsd:decimal"/>
+  </xsd:all>
+ </xsd:complexType>
+
+<!-- System events can be current user commands, interserver communications, 
+or the execution of previously set triggers -->
+ <xsd:complexType name="SystemEventType">
+  <xsd:all>
+   <xsd:element name="timestamp" type="unixTimeLimits"/>
+   <xsd:element name="server" type="xsd:string"/>
+   <xsd:element name="transactionNum" type="xsd:positiveInteger"/>
+   <xsd:element name="command" type="commandType"/>
+   <xsd:element name="username" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="stockSymbol" type="stockSymbolType" minOccurs="0"/>
+   <xsd:element name="filename" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="funds" type="xsd:decimal" minOccurs="0"/>
+  </xsd:all>
+ </xsd:complexType>
+
+<!-- Error messages contain all the information of user commands, in 
+addition to an optional error message -->
+ <xsd:complexType name="ErrorEventType">
+  <xsd:all>
+   <xsd:element name="timestamp" type="unixTimeLimits"/>
+   <xsd:element name="server" type="xsd:string"/>
+   <xsd:element name="transactionNum" type="xsd:positiveInteger"/>
+   <xsd:element name="command" type="commandType"/>
+   <xsd:element name="username" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="stockSymbol" type="stockSymbolType" minOccurs="0"/>
+   <xsd:element name="filename" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="funds" type="xsd:decimal" minOccurs="0"/>
+   <xsd:element name="errorMessage" type="xsd:string" minOccurs="0"/>
+  </xsd:all> 
+ </xsd:complexType>
+
+<!-- Debugging messages contain all the information of user commands, in 
+addition to an optional debug message -->
+ <xsd:complexType name="DebugType">
+  <xsd:all>
+   <xsd:element name="timestamp" type="unixTimeLimits"/>
+   <xsd:element name="server" type="xsd:string"/>
+   <xsd:element name="transactionNum" type="xsd:positiveInteger"/>
+   <xsd:element name="command" type="commandType"/>
+   <xsd:element name="username" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="stockSymbol" type="stockSymbolType" minOccurs="0"/>
+   <xsd:element name="filename" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="funds" type="xsd:decimal" minOccurs="0"/>
+   <xsd:element name="debugMessage" type="xsd:string" minOccurs="0"/>
+  </xsd:all>
+ </xsd:complexType>
+
+<!-- All Unix timestamps provided must be within the current semester -->
+ <xsd:simpleType name="unixTimeLimits">
+  <xsd:restriction base="xsd:integer">
+
+	 <xsd:minInclusive value="1483257601000"/> <!-- Jan 1, 2017 -->
+	 <xsd:maxInclusive value="1493622001000"/><!--May 1, 2017 -->
+
+
+</xsd:restriction>
+ </xsd:simpleType>
+
+<!-- Stock symbols are always three or fewer letters long -->
+ <xsd:simpleType name="stockSymbolType">
+  <xsd:restriction base="xsd:string">
+   <xsd:maxLength value="3"/>
+  </xsd:restriction>
+ </xsd:simpleType>
+
+<!-- Enumeration of the very specific commands accepted in the system -->
+ <xsd:simpleType name="commandType">
+  <xsd:restriction base="xsd:string">
+   <xsd:enumeration value="ADD"/>
+   <xsd:enumeration value="QUOTE"/>
+   <xsd:enumeration value="BUY"/>
+   <xsd:enumeration value="COMMIT_BUY"/>
+   <xsd:enumeration value="CANCEL_BUY"/>
+   <xsd:enumeration value="SELL"/>
+   <xsd:enumeration value="COMMIT_SELL"/>
+   <xsd:enumeration value="CANCEL_SELL"/>
+   <xsd:enumeration value="SET_BUY_AMOUNT"/>
+   <xsd:enumeration value="CANCEL_SET_BUY"/>
+   <xsd:enumeration value="SET_BUY_TRIGGER"/>
+   <xsd:enumeration value="SET_SELL_AMOUNT"/>
+   <xsd:enumeration value="SET_SELL_TRIGGER"/>
+   <xsd:enumeration value="CANCEL_SET_SELL"/>
+   <xsd:enumeration value="DUMPLOG"/>
+   <xsd:enumeration value="DISPLAY_SUMMARY"/>
+  </xsd:restriction>
+ </xsd:simpleType>
+
+</xsd:schema>

--- a/quotecache/quotecache.go
+++ b/quotecache/quotecache.go
@@ -78,7 +78,7 @@ func GetQuote(userID, stock string, transactionID int) (Quote, error) {
 		<cryptokey>%s</cryptokey>
 	</quoteServer>`,
 		time.Now().Unix()*1000, transactionID, userQuote.Price.ToFloat(),
-		userQuote.Stock, userQuote.UserID, userQuote.Timestamp.Unix()*1000,
+		userQuote.Stock, userQuote.UserID, userQuote.Timestamp.Unix(),
 		userQuote.Cryptokey,
 	)
 
@@ -96,7 +96,7 @@ func updateQuoteCache(userID, stock string) error {
 	defer conn.Close()
 
 	// Send that request!
-	request := fmt.Sprintf("%s,%s", stock, userID)
+	request := fmt.Sprintf("%s,%s\n", stock, userID)
 	conn.Write([]byte(request))
 
 	// listen for response

--- a/quotecache/quotecache.go
+++ b/quotecache/quotecache.go
@@ -16,11 +16,12 @@ import (
 
 // Quote : Stored response from the quoteserver
 type Quote struct {
-	UserID    string
-	Stock     string
-	Price     currency.Currency
-	Timestamp time.Time
-	Cryptokey string
+	UserID        string
+	Stock         string
+	Price         currency.Currency
+	Timestamp     time.Time
+	Cryptokey     string
+	TransactionID int
 }
 
 // IsExpired : True if the quotes timestamp is older than its validity window
@@ -33,7 +34,7 @@ func (q Quote) IsExpired() bool {
 var quoteCache = make(map[string]map[string]Quote)
 
 // GetQuote : Gets the current value of the stock, hitting the local cache if it can.
-func GetQuote(userID, stock string) (Quote, error) {
+func GetQuote(userID, stock string, transactionID int) (Quote, error) {
 	// check if the value is in cache
 
 	var userQuote Quote
@@ -45,13 +46,21 @@ func GetQuote(userID, stock string) (Quote, error) {
 	}
 	//Failed to get from cache, go do it outselves.
 
-	//get it from the quote server
+	// get it from the quote server
 	err := updateQuoteCache(userID, stock)
 	if err != nil {
 		return Quote{}, err
 	}
 
+	// Tag the quote with the transaction that caused the server hit.
+	//
+	// We have to get the new quote, modify it and write it back to the
+	// cache because... go doesn't like accessing properties of indexed
+	// items :p. The alternative is pass the transaction ID all the way
+	// down to parseQuote() but that's way too deep.
 	userQuote = quoteCache[stock][userID]
+	userQuote.TransactionID = transactionID
+	quoteCache[stock][userID] = userQuote
 
 	return userQuote, nil
 }


### PR DESCRIPTION
- Writes to timestamped `.xml` files in `./logs`
  - `<userCommand>` -> lines in the workload files
  - `<quoteServer>` -> hits to the _actual_ quoteserver, not our cache
  - **Logfile is agnostic about command completion**

Probably going to be a lot of conflicts with #28 and #31 because I do a global rename of the console logger, `log -> consoleLog` to distinguish it from the audit logger.
